### PR TITLE
confgi.skipUrlNormalization option

### DIFF
--- a/css-builder.js
+++ b/css-builder.js
@@ -144,7 +144,7 @@ define(['require', './normalize'], function(req, normalize) {
     }
 
     //add to the buffer
-    cssBuffer[name] = normalize(loadFile(fileUrl), fileSiteUrl, siteRoot);
+    cssBuffer[name] = config.skipUrlNormalization ? loadFile(fileUrl) : normalize(loadFile(fileUrl), fileSiteUrl, siteRoot);
 
     load();
   }


### PR DESCRIPTION
This must have been done a long time ago, all assets like images and fonts can be copied over preserving structure of folders.
Contra: if 2 libs have same image001.jpg then we have a collision
